### PR TITLE
Disable XDebug for CLI PHP tools

### DIFF
--- a/soe/_conf/php/30-xdebug-conf.ini
+++ b/soe/_conf/php/30-xdebug-conf.ini
@@ -1,0 +1,9 @@
+; Xdebug Config for Apache
+[xdebug]
+xdebug.profiler_enable = 0
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 0
+xdebug.remote_host = hostbox
+xdebug.remote_port = 9000
+xdebug.max_nesting_level = 1000

--- a/soe/php5.3/Dockerfile
+++ b/soe/php5.3/Dockerfile
@@ -58,14 +58,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 # Configure PHP.
 ADD ./conf/php/30-overrides.ini /etc/php5/apache2/conf.d/30-overrides.ini
 
-# Setup Xdebug
-RUN echo "xdebug.profiler_enable = 0 \n\
-xdebug.remote_enable = 1 \n\
-xdebug.remote_autostart = 1 \n\
-xdebug.remote_connect_back = 0 \n\
-xdebug.remote_host = hostbox \n\
-xdebug.remote_port = 9000 \n\
-xdebug.max_nesting_level = 1000" >> /etc/php5/conf.d/xdebug.ini
+# Setup Xdebug.
+ADD ./conf/php/30-xdebug-conf.ini /etc/php5/apache2/conf.d/30-xdebug-conf.ini
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/soe/php5.3/conf/php/30-xdebug-conf.ini
+++ b/soe/php5.3/conf/php/30-xdebug-conf.ini
@@ -1,0 +1,9 @@
+; Xdebug Config for Apache
+[xdebug]
+xdebug.profiler_enable = 0
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 0
+xdebug.remote_host = hostbox
+xdebug.remote_port = 9000
+xdebug.max_nesting_level = 1000

--- a/soe/php5.4/Dockerfile
+++ b/soe/php5.4/Dockerfile
@@ -64,6 +64,7 @@ ADD ./conf/php/30-overrides.ini /etc/php5/apache2/conf.d/30-overrides.ini
 RUN pecl install xdebug
 
 # Setup Xdebug.
+ADD ./conf/php/xdebug.ini /etc/php5/mods-available/xdebug.ini
 RUN php5enmod xdebug
 ADD ./conf/php/30-xdebug-conf.ini /etc/php5/apache2/conf.d/30-xdebug-conf.ini
 

--- a/soe/php5.4/Dockerfile
+++ b/soe/php5.4/Dockerfile
@@ -63,16 +63,9 @@ ADD ./conf/php/30-overrides.ini /etc/php5/apache2/conf.d/30-overrides.ini
 # PPA version.
 RUN pecl install xdebug
 
-# Setup Xdebug
-RUN echo "zend_extension=/usr/lib/php5/20100525/xdebug.so \n\
-xdebug.profiler_enable = 0 \n\
-xdebug.remote_enable = 1 \n\
-xdebug.remote_autostart = 1 \n\
-xdebug.remote_connect_back = 0 \n\
-xdebug.remote_host = hostbox \n\
-xdebug.remote_port = 9000 \n\
-xdebug.max_nesting_level = 1000" >> /etc/php5/mods-available/xdebug.ini
+# Setup Xdebug.
 RUN php5enmod xdebug
+ADD ./conf/php/30-xdebug-conf.ini /etc/php5/apache2/conf.d/30-xdebug-conf.ini
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/soe/php5.4/conf/php/30-xdebug-conf.ini
+++ b/soe/php5.4/conf/php/30-xdebug-conf.ini
@@ -1,0 +1,9 @@
+; Xdebug Config for Apache
+[xdebug]
+xdebug.profiler_enable = 0
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 0
+xdebug.remote_host = hostbox
+xdebug.remote_port = 9000
+xdebug.max_nesting_level = 1000

--- a/soe/php5.4/conf/php/xdebug.ini
+++ b/soe/php5.4/conf/php/xdebug.ini
@@ -1,0 +1,1 @@
+zend_extension=/usr/lib/php5/20100525/xdebug.so

--- a/soe/php5.5/Dockerfile
+++ b/soe/php5.5/Dockerfile
@@ -60,14 +60,8 @@ ADD ./conf/php/30-overrides.ini /etc/php5/apache2/conf.d/30-overrides.ini
 # Enable PHP modules.
 RUN php5enmod opcache
 
-# Setup Xdebug
-RUN echo "xdebug.profiler_enable = 0 \n\
-xdebug.remote_enable = 1 \n\
-xdebug.remote_autostart = 1 \n\
-xdebug.remote_connect_back = 0 \n\
-xdebug.remote_host = hostbox \n\
-xdebug.remote_port = 9000 \n\
-xdebug.max_nesting_level = 1000" >> /etc/php5/mods-available/xdebug.ini
+# Setup Xdebug.
+ADD ./conf/php/30-xdebug-conf.ini /etc/php5/apache2/conf.d/30-xdebug-conf.ini
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/soe/php5.5/conf/php/30-xdebug-conf.ini
+++ b/soe/php5.5/conf/php/30-xdebug-conf.ini
@@ -1,0 +1,9 @@
+; Xdebug Config for Apache
+[xdebug]
+xdebug.profiler_enable = 0
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 0
+xdebug.remote_host = hostbox
+xdebug.remote_port = 9000
+xdebug.max_nesting_level = 1000

--- a/soe/php5.6/Dockerfile
+++ b/soe/php5.6/Dockerfile
@@ -62,14 +62,8 @@ ADD ./conf/php/30-overrides.ini /etc/php5/apache2/conf.d/30-overrides.ini
 # Enable PHP modules.
 RUN php5enmod opcache
 
-# Setup Xdebug
-RUN echo "xdebug.profiler_enable = 0 \n\
-xdebug.remote_enable = 1 \n\
-xdebug.remote_autostart = 1 \n\
-xdebug.remote_connect_back = 0 \n\
-xdebug.remote_host = hostbox \n\
-xdebug.remote_port = 9000 \n\
-xdebug.max_nesting_level = 1000" >> /etc/php5/mods-available/xdebug.ini
+# Setup Xdebug.
+ADD ./conf/php/30-xdebug-conf.ini /etc/php5/apache2/conf.d/30-xdebug-conf.ini
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/soe/php5.6/conf/php/30-xdebug-conf.ini
+++ b/soe/php5.6/conf/php/30-xdebug-conf.ini
@@ -1,0 +1,9 @@
+; Xdebug Config for Apache
+[xdebug]
+xdebug.profiler_enable = 0
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 0
+xdebug.remote_host = hostbox
+xdebug.remote_port = 9000
+xdebug.max_nesting_level = 1000


### PR DESCRIPTION
This prevents things like `drush` from hanging while debugging.
